### PR TITLE
Tag a new version of compose.yml on auto-update

### DIFF
--- a/.github/workflows/update-service-image.yml
+++ b/.github/workflows/update-service-image.yml
@@ -21,3 +21,10 @@ jobs:
     - run: git commit -m "Auto-update service image to ${{ github.event.inputs.image-tag }}"
     - run: git log --graph --decorate --all
     - run: git push
+    # Note the following VERSION is of this repo, of the compose.yml,
+    # which is distinct from the service image version from the service
+    # repo passed in above. Multiple components exist in the compose
+    # file and also configuration so it has a separate version.
+    - run: echo VERSION=$(git log -1 --date=unix --pretty=format:"%cd" | date --utc +%Y%m%d)-$(git log -1 --pretty=format:"%h") >> $GITHUB_ENV
+    - run: git tag ${{ env.VERSION }}
+    - run: git push origin ${{ env.VERSION }}


### PR DESCRIPTION
When a new version of the service image gets added to the compose.yml
automatically then tag the compose.yml with a new version as well.
The service image is only one dependency (or library, if you will) that
the compose.yml uses and therefore the versions of the high-level script
are tracked independently of the versions of software it uses.

Issue #8 Add (or update) action to tag new versions of the compose.yml