### PR TITLE
Add workflow that writes a tag to the test machine

### DIFF
--- a/.github/workflows/send-tag-to-machine.yml
+++ b/.github/workflows/send-tag-to-machine.yml
@@ -1,0 +1,23 @@
+name: Send tag to machine
+
+on:
+  create:
+    ref-type:
+      tag:
+        - '[0-9a-z_-]*'
+
+jobs:
+  send-tag-to-machine:
+    runs-on: ubuntu-latest
+    environment: test
+    steps:
+    - run: echo ${{ github.ref }} > tag_to_deploy
+    - run: cat tag_to_deploy
+    - run: ls -la tag_to_deploy
+    - run: chmod 660 tag_to_deploy
+    - run: touch ssh_id
+    - run: chmod 700 ssh_id
+    - run: echo ${{ secrets.BUILD_SSH_PRIVATE_KEY }} > ssh_id
+    - run: ls -la ssh_id
+    - run: sha256sum ssh_id
+    - run: scp -i ssh_id tag_to_deploy build@{{ secrets.MACHINE_ADDRESS }}:/home/build/tag_to_deploy


### PR DESCRIPTION
This relies on an "environment" named "test" having some secrets as well
as some configuration on the test machine to allow remote access. At the
moment the access attempt should fail.

Issue #9 Add (or update) action to send a tag version to a machine