### PR TITLE
Allow TAG_FILE to be set by the environment

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -38,7 +38,7 @@ test ! -z "$REPOSITORY_PREFIX" || exit 3
 test ! -z "$REPOSITORY_FILE" || exit 4
 
 # The tag file is expected to contain a tag to release on line 1.
-TAG_FILE=./tag_file
+TAG_FILE="${TAG_FILE:-./tag_file}"
 
 # The file at $COMPOSE_NAME_FILE contains the name of the running
 # compose file. This is not expected to be present on first run.


### PR DESCRIPTION
This lets the deploy.sh script look in other places besides "./tag_file"

Issue #9 Add (or update) action to send a tag version to a machine