### PR TITLE
Point the reverse proxy to custom TLS cert

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -8,6 +8,8 @@ services:
       - "443:8443"
     volumes:
       - ${NGINX_CONF}:/opt/bitnami/nginx/conf/server_blocks/vhost.conf:ro
+      - ${NGINX_CERT}:/opt/bitnami/nginx/conf/server.crt:ro
+      - ${NGINX_KEY}:/opt/bitnami/nginx/conf/server.key:ro
   web:
     image: ghcr.io/philanthropydatacommons/service:20220708-62920b0
     user: ${WEB_CONTAINER_USER}


### PR DESCRIPTION
The deploy user .env must include NGINX_CONF, NGINX_CERT, and NGINX_KEY.
This also assumes the conf at NGINX_CONF enables SSL/TLS on port 8443
inside the container, notice the compose.yml exposes it as 443 outside.

Issue #2 Set up TLS