### PR TITLE
Set scp UserKnownHostsFile option before source

### DIFF
--- a/.github/workflows/send-tag-to-machine.yml
+++ b/.github/workflows/send-tag-to-machine.yml
@@ -22,4 +22,4 @@ jobs:
     - run: touch ~/my_known_hosts
     - run: chmod 700 ~/my_known_hosts
     - run: echo "${{ secrets.KNOWN_HOSTS }}" > ~/my_known_hosts
-    - run: scp -i ssh_id tag_to_deploy -o UserKnownHostsFile=~/my_known_hosts build@${{ secrets.MACHINE_ADDRESS }}:/home/build/tag_to_deploy
+    - run: scp -i ssh_id -o UserKnownHostsFile=~/my_known_hosts tag_to_deploy build@${{ secrets.MACHINE_ADDRESS }}:/home/build/tag_to_deploy


### PR DESCRIPTION
This might resolve the host key verification issue from GitHub runners.

Issue #9 Add (or update) action to send a tag version to a machine