### PR TITLE
Specify directories more precisely

### DIFF
--- a/.github/workflows/send-tag-to-machine.yml
+++ b/.github/workflows/send-tag-to-machine.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: test
     steps:
-    - run: echo ${{ github.ref_name }} > tag_to_deploy
-    - run: chmod 660 tag_to_deploy
-    - run: touch ssh_id
-    - run: chmod 700 ssh_id
-    - run: echo "${{ secrets.BUILD_SSH_PRIVATE_KEY }}" > ssh_id
+    - run: echo ${{ github.ref_name }} > ~/tag_to_deploy
+    - run: chmod 660 ~/tag_to_deploy
+    - run: touch ~/ssh_id
+    - run: chmod 700 ~/ssh_id
+    - run: echo "${{ secrets.BUILD_SSH_PRIVATE_KEY }}" > ~/ssh_id
     - run: touch ~/my_known_hosts
     - run: chmod 700 ~/my_known_hosts
     - run: echo "${{ secrets.KNOWN_HOSTS }}" > ~/my_known_hosts
-    - run: scp -i ssh_id -o UserKnownHostsFile=~/my_known_hosts -p tag_to_deploy build@${{ secrets.MACHINE_ADDRESS }}:/home/build/tag_to_deploy
+    - run: scp -v -i ~/ssh_id -o UserKnownHostsFile=~/my_known_hosts -p ~/tag_to_deploy build@${{ secrets.MACHINE_ADDRESS }}:/home/build/tag_to_deploy


### PR DESCRIPTION
Consistently use ~/file and add verbose logging to a frequently-failing
command.

Issue #9 Add (or update) action to send a tag version to a machine