### PR TITLE
Upgrade postgresql and nginx

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,7 +1,7 @@
 version: "2.4"
 services:
   reverse-proxy:
-    image: bitnami/nginx:1.22.0-debian-11-r16
+    image: bitnami/nginx:1.22.1-debian-11-r7
     user: ${REVERSE_PROXY_CONTAINER_USER}
     ports:
       # Purposely omit port 80 in order to run ACME clients standalone.
@@ -32,7 +32,7 @@ services:
       database:
         condition: service_healthy
   database:
-    image: bitnami/postgresql:14.4.0-debian-11-r9
+    image: bitnami/postgresql:14.5.0-debian-11-r40
     user: ${DATABASE_CONTAINER_USER}
     volumes:
       - ${PG_DATA}:/bitnami/postgresql


### PR DESCRIPTION
Upgrades the images of postgresql and nginx to bitnami's 1.22.1-debian-11-r7 and 14.5.0-debian-11-r40 respectively.