### PR TITLE
Pass API_KEYS_FILE env var to web container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,4 @@ REVERSE_PROXY_CONTAINER_USER=903
 NGINX_CONF=/home/reverse-proxy/proxy.conf
 NGINX_CERT=/home/reverse-proxy/cert.pem
 NGINX_KEY=/home/reverse-proxy/key.pem
+API_KEYS_FILE=/home/web/secret_api_keys.txt

--- a/compose.yml
+++ b/compose.yml
@@ -26,6 +26,7 @@ services:
       - PGPASSWORD=${PG_PASS}
       - PGDATABASE=${PG_DB}
       - PGPORT=${PG_PORT}
+      - API_KEYS_FILE=${API_KEYS_FILE}
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://web:3000"]
     depends_on:


### PR DESCRIPTION
See these links in the service project:

* https://github.com/PhilanthropyDataCommons/service/pull/113
* https://github.com/PhilanthropyDataCommons/service/issues/96

The temporary approach is to use a local file with secret API keys. The name of the	file to	access is specified by the deploy user but the file is	generated by and accessible to the web user.