### PR TITLE
Add a certificate renewal script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ ZULIP_BOT_API_KEY=
 ZULIP_STREAM=
 ZULIP_TOPIC=
 
+# This var (and others above and below) are used by renewCerts.sh
+WEB_SERVER_HOSTNAME=replace_this_with_the_pdc_service_hostname
+
 # The remaining variables are for the compose.yml script
 DATABASE_CONTAINER_USER=901
 PG_DATA=/home/database
@@ -18,6 +21,7 @@ PG_DB=pdc
 PG_PORT=5432
 WEB_CONTAINER_USER=902
 REVERSE_PROXY_CONTAINER_USER=903
+REVERSE_PROXY_CONTAINER_GROUP=903
 # Permission issues can be avoided by creating the following files prior to
 # launching the compose script. For the certificate pairs, one could get started
 # with a single self-signed certificate for both web and auth.

--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,6 @@ ZULIP_TOPIC=
 
 # The remaining variables are for the compose.yml script
 DATABASE_CONTAINER_USER=901
-DATABASE_CONTAINER_GROUP=901
 PG_DATA=/home/database
 PG_USER=pdc
 PG_PASS=you_should_replace_this_with_your_own_pdc_passphrase

--- a/compose.yml
+++ b/compose.yml
@@ -3,6 +3,8 @@ services:
   reverse-proxy:
     image: bitnami/nginx:1.23.3-debian-11-r30
     user: ${REVERSE_PROXY_CONTAINER_USER}
+    group_add:
+      - ${REVERSE_PROXY_CONTAINER_GROUP}
     ports:
       # Purposely omit port 80 in order to run ACME clients standalone.
       - "443:8443"
@@ -16,6 +18,8 @@ services:
       - ${AUTH_KEY}:/opt/bitnami/nginx/conf/auth-key.pem:ro
       # A page to show when someone visits the auth service directly
       - ${AUTH_ROOT_PAGE}:/app/auth_root_page.html:ro
+      # When using letsencrypt, symlinks may go up a directory, mount whole dir
+      - /etc/letsencrypt:/etc/letsencrypt:ro
     depends_on:
       web:
         condition: service_healthy

--- a/renewCerts.sh
+++ b/renewCerts.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# A script to renew certificates with certbot and send chat message with result
+
+# Example usage, expected within crontab:
+# 0 18 * * SUN /home/deploy/renewCerts.sh
+
+# Requirements:
+# certbot (installed on the host, not in a container),
+# nginx already configured to point to letsencrypt certificates, and
+# Environment variables in /home/deploy/.env:
+# - REVERSE_PROXY_CONTAINER_GROUP
+# - WEB_SERVER_HOSTNAME
+# - AUTH_SERVER_HOSTNAME
+# - ZULIP_BASE_URL
+# - ZULIP_BOT_EMAIL_ADDRESS
+# - ZULIP_BOT_API_KEY
+# - ZULIP_STREAM
+# - ZULIP_TOPIC
+
+set -eo pipefail
+
+test -x "$(which certbot)"
+# Instead of sourcing /home/deploy/.env verbatim, source only strictly formed and used env vars.
+. <(egrep '^(WEB_SERVER_HOSTNAME|REVERSE_PROXY_CONTAINER_GROUP|AUTH_SERVER_HOSTNAME|ZULIP_BASE_URL|ZULIP_BOT_EMAIL_ADDRESS|ZULIP_BOT_API_KEY|ZULIP_STREAM|ZULIP_TOPIC)=[a-zA-Z0-9"\/\:\.\@\_\-]+$' /home/deploy/.env)
+test ! -z "$WEB_SERVER_HOSTNAME"
+test ! -z "$REVERSE_PROXY_CONTAINER_GROUP"
+test ! -z "$AUTH_SERVER_HOSTNAME"
+test ! -z "$ZULIP_BASE_URL"
+test ! -z "$ZULIP_BOT_EMAIL_ADDRESS"
+test ! -z "$ZULIP_BOT_API_KEY"
+test ! -z "$ZULIP_STREAM"
+test ! -z "$ZULIP_TOPIC"
+
+set +eo pipefail
+
+function fin() {
+    # Exit. Also notify of the result via chat if an API key is present.
+    exit_code=0
+    error_message=$1
+    message="✅ Certificate renewals (or checks) for https://${AUTH_SERVER_HOSTNAME} and https://${WEB_SERVER_HOSTNAME} succeeded."
+
+    if test ! -z "$error_message"; then
+        exit_code=1
+        message="❌ Certificate renewals (or checks) for https://${AUTH_SERVER_HOSTNAME} or https://${WEB_SERVER_HOSTNAME} FAILED: ${error_message}"
+    fi
+
+    curl -X POST ${ZULIP_BASE_URL}/api/v1/messages \
+        -u ${ZULIP_BOT_EMAIL_ADDRESS}:${ZULIP_BOT_API_KEY} \
+        --data-urlencode type=stream \
+        --data-urlencode to=${ZULIP_STREAM} \
+        --data-urlencode topic=${ZULIP_TOPIC} \
+        --data-urlencode "content=${message}"
+
+    exit $exit_code
+}
+
+certbot certonly -n --domain=$AUTH_SERVER_HOSTNAME --standalone --keep-until-expiring \
+    || fin $(tail -n 10 /var/log/letsencrypt/letsencrypt.log)
+certbot certonly -n --domain=$WEB_SERVER_HOSTNAME --standalone --keep-until-expiring \
+    || fin $(tail -n 10 /var/log/letsencrypt/letsencrypt.log)
+# Make sure the reverse proxy user has read/execute privileges on the cert and key files.
+chgrp -R $REVERSE_PROXY_CONTAINER_GROUP /etc/letsencrypt/{live,archive} \
+    || fin "Failed to chgrp /etc/letsencrypt/{live,archive} to $REVERSE_PROXY_CONTAINER_GROUP"
+chmod -R g+rx /etc/letsencrypt/{live,archive} \
+    || fin "Failed to add group read and execute permissions to /etc/letsencrypt/{live,archive}"
+docker exec deploy_reverse-proxy_1 nginx -s reload \
+    || fin "Failed to send reload signal to reverse proxy running in a container"
+(( $(docker ps | grep reverse-proxy | wc -l) == "1" )) \
+    || fin "The reverse-proxy container is no longer running"
+
+fin


### PR DESCRIPTION
When run by cron, this script automatically renews certificates using certbot for two hostnames and sends a chat message with the result.

Issue #64 Renew TLS certificates