### PR TITLE
Update some docs and examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,13 +26,13 @@ REVERSE_PROXY_CONTAINER_GROUP=903
 # launching the compose script. For the certificate pairs, one could get started
 # with a single self-signed certificate for both web and auth.
 NGINX_CONF=/home/reverse-proxy/proxy.conf
-WEB_CERT=/home/reverse-proxy/web-cert.pem
-WEB_KEY=/home/reverse-proxy/web-key.pem
-AUTH_CERT=/home/reverse-proxy/auth-cert.pem
-AUTH_KEY=/home/reverse-proxy/auth-key.pem
+WEB_CERT=/etc/letsencrypt/live/YOUR_WEB_DOMAIN_NAME_HERE/fullchain.pem
+WEB_KEY=/etc/letsencrypt/live/YOUR_WEB_DOMAIN_NAME_HERE/privkey.pem
+AUTH_CERT=/etc/letsencrypt/live/YOUR_AUTH_DOMAIN_NAME_HERE/fullchain.pem
+AUTH_KEY=/etc/letsencrypt/live/YOUR_AUTH_DOMAIN_NAME_HERE/privkey.pem
 AUTH_ROOT_PAGE=/home/reverse-proxy/auth_root_page.html
 AUTH_CONTAINER_USER=904
-KEYCLOAK_PG_INITDB_SCRIPT=/home/deploy/keycloakInitDb.sh
+KEYCLOAK_PG_INITDB_SCRIPT=/home/database/keycloakInitDb.sh
 KEYCLOAK_PG_PASSWORD=you_should_replace_this_with_your_own_keycloak_db_passphrase
 KEYCLOAK_ADMIN_PASSWORD=you_should_replace_this_with_your_own_keycloak_admin_passphrase
 KEYCLOAK_MANAGEMENT_PASSWORD=you_should_replace_this_with_your_own_keycloak_management_passphrase

--- a/README.md
+++ b/README.md
@@ -103,9 +103,11 @@ user able to run the docker commands.
 ## Logs
 
 Use the usual `docker ps` command to see which containers are running and the
-`docker logs {container_id}` to see logs for a given container.
+`docker logs {container_id}` to see logs for a given container. Also, logs may
+be found via `journalctl` with the `CONTAINER_NAME` as a filter, for example:
+`journalctl CONTAINER_NAME=deploy_database_1 --no-pager --utc`.
 
-## TLS configuration with letsencrypt client
+## TLS configuration with letsencrypt client using docker
 
 Given the included configuration examples, one can run the letsencrypt client
 in standalone mode and then copy the certificates to the configured key and
@@ -135,3 +137,11 @@ Then copy the keys and certificates:
 Reload or restart the reverse proxy container to use the certificate:
 
     sudo docker restart deploy_reverse-proxy_1
+
+## TLS configuration with letsencrypt client on host
+
+A preferred alternative to the above setup is to run letsencrypt on the host.
+An example script can be found at `renewCerts.sh`. In this case, one points
+the `WEB_CERT`, `WEB_KEY`, `AUTH_CERT`, and `AUTH_KEY` directly to the
+`/etc/letsencrypt` paths. The compose script already expects `/etc/letsencrypt`
+so it is a good idea to run letsencrypt manually before launch.

--- a/renewCerts.sh
+++ b/renewCerts.sh
@@ -3,7 +3,7 @@
 # A script to renew certificates with certbot and send chat message with result
 
 # Example usage, expected within crontab:
-# 0 18 * * SUN /home/deploy/renewCerts.sh
+# 0 18 * * SUN /root/renewCerts.sh
 
 # Requirements:
 # certbot (installed on the host, not in a container),


### PR DESCRIPTION
Do not put scripts for users other than the `deploy` user in `/home/deploy` but put them elsewhere. Update to show that letsencrypt is expected on the usual host path now.

Issue #75 Move the db init script default location