### PR TITLE
Validate the version tag contents

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -87,7 +87,7 @@ if [[ ! -f $TAG_FILE ]]; then
 fi
 
 
-VERSION=$(head -n 1 $TAG_FILE)
+VERSION=$(head -n 1 $TAG_FILE | egrep '^[a-zA-Z0-9\_\.\-]+$')
 test ! -z "$VERSION" || fin 6
 
 # In the filename, replace slashes with underscores. This way, we can


### PR DESCRIPTION
Make sure a version tag name starts at the beginning of the file containing the tag to deploy, only contains certain characters, and the line ends before any other characters appear. This should mitigate some attacks via the `deploy` user reading this file.

See (internal) discussion at:
https://chat.opentechstrategies.com/#narrow/stream/66-PDC/topic/ci.2Fcd/near/157900