### PR TITLE
Enable gzip HTTP compression for JSON data

### DIFF
--- a/proxy.conf.example
+++ b/proxy.conf.example
@@ -11,6 +11,8 @@ server {
     ssl_ciphers 'DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:TLS_AES_128_GCM_SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-CHACHA20-POLY1305:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256';
     add_header Strict-Transport-Security "max-age=31536000" always;
 
+    gzip_types application/json text/plain text/css application/javascript text/xml application/xml+rss;
+
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
After consideration of the [BREACH attack](https://breachattack.com) we enabled HTTP compression. The reason we do not think the back-end service is vulnerable to BREACH is the following. Even though some query or URL parameter data are reflected in the JSON body, all protected or secret data require a JSON Web Token auth header. When there is no valid authentication in the HTTP headers (which are not compressed), the response does not reflect query or URL parameter data. Therefore the attack described should not be possible without first compromising the credentials of a user at which point the attack would be pointless because the attacker had already gained access to protected or secret data by using the victim's credentials.

Issue #84 Compress API response