### PR TITLE
Add `DEPLOYING.md` and `UPGRADING.md` documents

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -1,0 +1,129 @@
+# Deploying Philanthropy Data Commons software
+
+This document guides one through deployment to production of the back-end
+Philanthropy Data Commons software to run at
+https://api.philanthropydatacommons.org and
+https://auth.philanthropydatacommons.org.
+
+The [data-viewer](https://github.com/PhilanthropyDataCommons/data-viewer/) at
+https://pilot.philanthropydatacommons.org has its own separate process.
+
+In brief, the process is to write a version to a file then verify that the
+deployment happened successfully.
+
+A Docker Compose YAML
+[file](https://github.com/PhilanthropyDataCommons/deploy/blob/main/compose.yml)
+is used to deploy. The file includes the PDC service ("web") and other services
+upon which PDC depends.
+
+A
+[bash script](https://github.com/PhilanthropyDataCommons/deploy/blob/main/deploy.sh)
+running under cron:
+ - gets the new compose file,
+ - pulls new components (images) using the new compose file,
+ - stops the old services (containers) using the old compose file,
+ - starts the new services (containers) using the new compose file,
+ - and notifies the team via chat message.
+
+To start to deploy and to find exactly what version to deploy, the script
+[looks inside a file](https://github.com/PhilanthropyDataCommons/deploy/blob/e0d24b8a19ee563938f8211bca0485a97ff1a6e9/deploy.sh#L90)
+currently `~build/deployment/tag_to_deploy`.
+
+This setup supports both automated and manual deployments that have exactly the
+same steps with exactly the same code.
+
+## To deploy a newly built version of the PDC service to production
+
+This is the streamlined case. It assumes that both the test and production
+machines were already set up with users, directories, Docker, Certbot, scripts,
+environment variables, additional Keycloak JAR files, and so forth.
+
+### Background
+
+When someone merges code to the main branch in the
+[service repository](https://github.com/PhilanthropyDataCommons/service),
+[GitHub Actions](https://github.com/PhilanthropyDataCommons/service/tree/main/.github/workflows)
+runs tests, builds a new Docker image with the PDC service and its dependencies,
+and pushes the new image to 
+[service packages](https://github.com/PhilanthropyDataCommons/service/pkgs/container/service)
+. The GitHub Actions also tag the new service image with a version, such as
+`20230616-00a3cc8`. The tag is on the binary, not the source code, but the
+version text is based on the git commit, so that we can always trace the image
+back back to the source code whence it came.
+
+The
+[GitHub Action](https://github.com/PhilanthropyDataCommons/service/blob/cd2e2a4c39d87479f7b145a9163e155ede7676f2/.github/workflows/build.yml#L46)
+that builds and pushes an image also triggers an
+[Action](https://github.com/PhilanthropyDataCommons/deploy/blob/main/.github/workflows/update-service-image.yml)
+in the deploy repository which in turn updates the compose.yml with the
+newly created image version of the service, tags the compose.yml with a
+version, and
+[automatically deploys](https://github.com/PhilanthropyDataCommons/deploy/blob/e0d24b8a19ee563938f8211bca0485a97ff1a6e9/.github/workflows/send-tag-to-machine.yml#L22)
+PDC software to the test environment using the newly updated and tagged
+compose.yml.
+
+The rest of this guide assumes you saw that tests passed and you want to deploy
+the recently built and tested version of the PDC service to the production
+environment.
+
+### Verify that the deployment to the test environment succeeded
+
+1. Check the
+[PDC ci/cd chat](https://chat.opentechstrategies.com/#narrow/stream/75-PDC/topic/ci.2Fcd)
+for the most recent message from "PDC Testing Bot" containing the tagged
+`compose.yml` file, e.g. "Deployment of https://.../20230613-e0d24b8/compose.yml
+succeeded." Success here means the deploy script exited 0 which means the Docker
+Compose commands succeeded.
+2. Check the
+[back-end service docs in the test environment](https://api-test.philanthropydatacommons.org)
+. If the swagger docs show up, this means the reverse-proxy container (nginx)
+and web container (Node.js) are running.
+3. Check the
+[auth service in the test environment](https://auth-test.philanthropydatacommons.org/realms/pdc)
+. If a JSON doc shows up, this means the reverse-proxy container (nginx), auth
+container (Keycloak), and database container (PostgreSQL) are running.
+
+### Check for active sessions in production
+
+Visit
+[PDC sessions in Keycloak](https://auth.philanthropydatacommons.org/admin/master/console/#/pdc/sessions)
+.
+
+If there are non-PDC-team users active, wait until there is a comfortable amount
+of time since last activity, e.g. 30 mins.
+
+### Copy the Docker Compose file version to your clipboard
+
+The version ID can be found in the
+[deploy project's tags](https://github.com/PhilanthropyDataCommons/deploy/tags)
+or in the url in the chat message from the "PDC Testing Bot" above. In the
+example above the version is `20230613-e0d24b8`.
+
+### Tell the deploy script the version of the Docker Compose file to deploy
+
+These are the commands that actually deploy the software.
+
+ - `ssh $OTS_USERNAME@api.philanthropydatacommons.org`
+
+In the next command, replace VERSION with the compose file version:
+
+ - `echo "VERSION" | sudo -u build tee ~build/deployment/tag_to_deploy`
+ - `exit`
+
+### Verify that the deployment to the production environment succeeded
+
+(Continuing the above session at `api.philanthropydatacommons.org` as
+`$OTS_USERNAME`):
+ - `sudo docker ps`
+
+Repeat this command every few seconds until you see the old containers go down
+and new containers come up. When all containers are up (presently four), this
+means the deployment should be successful. To be extra sure one can also repeat
+the same steps from the test environment above, i.e.:
+
+1. Check https://chat.opentechstrategies.com/#narrow/stream/75-PDC/topic/ci.2Fcd
+for the most recent message from "PDC Production Bot".
+2. Check https://api.philanthropydatacommons.org
+3. Check https://auth.philanthropydatacommons.org/realms/pdc
+4. For good measure, check https://pilot.philanthropydatacommons.org to verify
+it reaches the back-end service.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ component repositories because they operate above a source-code level, are
 optional, and they can work with multiple PDC services above any given PDC
 service's level.
 
+This README describes components of a deployment pipeline. For specific steps to
+deploy or upgrade using the existing production deployment pipeline, see
+[DEPLOYING](./DEPLOYING.md) and [UPGRADING](./UPGRADING.md).
+
 ## compose.yml
 
 The `compose.yml` is the thing to be deployed. It contains declarations or

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,159 @@
+# Upgrading Philanthropy Data Commons dependencies
+
+This document guides one through upgrades to production back-end services at
+https://api.philanthropydatacommons.org and
+https://auth.philanthropydatacommons.org.
+
+The [data-viewer](https://github.com/PhilanthropyDataCommons/data-viewer) at
+https://pilot.philanthropydatacommons.org has its own separate process.
+
+This applies to the non-PDC-web-container services. As of this writing that is
+the auth, database, and reverse-proxy services. The rest is either in the PDC
+web service, such as Node.js dependencies managed in the
+[service project](https://github.com/PhilanthropyDataCommons/service/blob/main/package.json)
+, or on the host, such as cert-bot.
+
+See the summary in [DEPLOYING](./DEPLOYING.md) regarding how software gets
+deployed. The same deployment steps apply to the upgrades described here.
+
+In general, try it on a local development environment first, then make sure it
+succeeds in the test environment, then finally do it in production.
+
+## Upgrade PostgreSQL (minor version)
+
+Caution: do not use "latest". That won't work the way we want. Also do not use a
+less-specific version such as 14-debian-11 or 14.8.0 but only the most specific
+image versions such as 14.8.0-debian-11-r14. The purpose of using Bitnami images
+is they offer specific tags that only have one image associated. This means we
+can deploy exactly the images we tested to production, can pull the same images
+when reproducing production issues in a local development environment, and more.
+
+0. Clone or pull [the repo](https://github.com/PhilanthropyDataCommons/deploy).
+1. In your local clone of the repo, open the `compose.yml` file.
+2. Look at the current version of the `database` image under "database: image:".
+3. Visit
+[bitnami/postgresql images](https://hub.docker.com/r/bitnami/postgresql/tags).
+4. Find the most recent and highest version of the major version of PostgreSQL.
+For example, if using PostgreSQL 14, it might be 14.8.0-debian-11-r14.
+5. Replace the version in the `compose.yml` file and save the file.
+6. Test the pull locally with that compose.yml:
+  - `docker compose -f compose.yml pull` (Some systems: `docker-compose`).
+If the pull succeeded, continue, otherwise re-check the previous couple steps.
+7. Create a pull request to merge the change to main.
+8. After merge to main, create a tag on the commit that has your changes.
+The tag will be the date in UTC of the commit (in main) followed by the first
+seven digits of the git commit hash. For example, if the commit was like this:
+`e0d24b8a19ee563938f8211bca0485a97ff1a6e9...Tue Jun 13 19:00:38 2023 +0000`, the
+tag would be `20230613-e0d24b8`.
+  - `git log --graph --decorate --all` (To find the right commit on main)
+  - `git tag [version] [commit]`
+  - `git log --graph --decorate --all` (To double-check correct tag happened)
+  - `git push origin [tag]` (The [tag] here is the same as the [version] above)
+There is an
+[opportunity](https://github.com/PhilanthropyDataCommons/deploy/issues/31)
+to automate this step as it has been automated for service image deployments.
+9. Deploy the newly tagged compose script as usual, start in the `deploying.md`
+section titled "Verify that the deployment to the test environment succeeded."
+
+## Upgrade Keycloak (minor version)
+
+The steps are the same as PostgreSQL above, except look for the Keycloak image
+at [Docker Hub](https://hub.docker.com/r/bitnami/keycloak/tags) and replace the
+version under "auth: image:".
+
+## Upgrade nginx (minor version)
+
+The steps are the same as PostgreSQL and Keycloak above, except look for the
+Bitnami nginx image at
+[Docker Hub](https://hub.docker.com/r/bitnami/nginx/tags) and replace the
+version under "reverse-proxy: image:".
+
+## Upgrade PostgreSQL (major version)
+
+A major PostgreSQL version upgrade is quite a bit more involved than changing a
+line in a file and tagging it. There are multiple ways to do it. See the related
+[official PostgreSQL docs](https://www.postgresql.org/docs/current/upgrading.html).
+
+### The `pg_dumpall` and `pg_restore` way
+
+This is probably the best way.
+
+See the related
+[PostgreSQL docs](https://www.postgresql.org/docs/current/upgrading.html#UPGRADING-VIA-PGDUMPALL)
+.
+
+### The `pg_upgrade` way
+
+While this way is not preferred, the steps are elaborated below. Once the steps
+for the `pg_dumpall` and `pg_restore` have been elaborated, this section can be
+ignored or removed.
+
+Official PostgreSQL documentation mentions
+[pg_upgrade](https://www.postgresql.org/docs/current/pgupgrade.html). The
+`pg_upgrade` tool requires the binaries of the old version and old configuration
+directory in order to perform a migration of the old data format to the new data
+format.
+
+To provide access to the binaries of the old PostgreSQL image in the new image,
+copy them from the image to a new directory and mount it in the new image.
+
+Be careful not to start PostgreSQL using the Bitnami image until after upgrade.
+
+In a shell with the old PostgreSQL database running:
+
+- `sudo docker exec -ti deploy-database-1 /bin/bash`
+
+Copy the old binaries to a specific old binaries dir (e.g. 14):
+
+- `mkdir /bitnami/postgresql/pg14bin`
+- `cp -r /opt/bitnami/postgresql/bin/* /bitnami/postgresql/pg14bin/`
+
+Stop the old PostgreSQL database:
+
+- `pg_ctl stop -D /bitnami/postgresql/data`
+
+This will kick you out of the container because it is now dead.
+
+Now run a container from the old image, with env vars, e.g.
+
+- `sudo docker compose -f compose-[version].yml run -ti database /bin/bash`
+
+Move the old data from old directory to a new specific old directory:
+
+- `mv /opt/bitnami/postgresql/data /bitnami/postgresql/data.old`
+
+Copy the old postgresql.conf, pg_hba.conf, and conf.d contents to the old data
+directory and exit the container:
+
+- `cp /opt/bitnami/postgresql/conf/*.conf /bitnami/postgresql/data.old/`
+- `cp -r /bitnami/postgresql/conf.d /bitnami/postgresql/data.old/`
+- `exit`
+
+Create a new directory for the new PostgreSQL data.
+Now we need to init db but without the `pdc` user, only the `postgres` user.
+In a shell in the container running the new PostgreSQL, with volumes mounted to
+the same locations as the old, initialize the new database:
+
+- `initdb -U postgres data.new`
+
+Perform the upgrade:
+
+- `cd /bitnami/postgresql`
+- `pg_upgrade -U postgres --old-datadir /bitnami/postgresql/data.old --new-datadir /bitnami/potsgresql/data.new --old-bindir /bitnami/postgresql/pg14bin --new-bindir /opt/bitnami/postgresql/bin`
+
+### The replication way
+
+If minimal downtime becomes important the replication way may become helpful.
+
+See the related
+[PostgreSQL docs](https://www.postgresql.org/docs/current/upgrading.html#UPGRADING-VIA-REPLICATION)
+.
+
+## Upgrade Keycloak (major version)
+
+From major version 20 to major version 21, there appears to be no database data
+issue when pointing to the same database instance. From major version 20 to
+major version 21, there may be a compatibility issue with
+[the custom extensions](https://github.com/PhilanthropyDataCommons/auth), so the
+extensions should be recompiled against the major version 21 API and tested 
+prior to attempting the upgrade in production.

--- a/deploy.crontab
+++ b/deploy.crontab
@@ -1,0 +1,6 @@
+# This is the crontab of the `deploy` user. It runs the `deploy.sh` script.
+
+# Every minute run the deployment script and print to an hourly file.
+* * * * * /bin/bash ~/deploy.sh >> ~/deploy_$(date +\%Y-\%m-\%dT\%H --utc).log 2>&1
+# Every day at T06Z remove 90+ day-old deployment logs.
+0 6 * * * find ~ -maxdepth 1 -type f -name "deploy_*.log" -mtime +90 -delete


### PR DESCRIPTION
The documentation in this repo so far has descriptions of the elements
in a potential deployment pipeline but lacked a step-by-step guide to
deploy PDC in the actual instance of the PDC's pipeline. This commit
resolves the gap by adding more concrete guides in `DEPLOYING.md` and
`UPGRADING.md`. "Deploying" here means "how to deploy to production"
and "upgrading" here means "how to update a service-level dependency
such as postgresql in production."

Issue https://code.librehq.com/ots/infra/admin-tasks/-/issues/63
Issue https://code.librehq.com/ots/infra/admin-tasks/-/issues/64