### PR TITLE
Add a dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: ".github/workflows"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 2


### PR DESCRIPTION
Hopefully dependabot will "just work" but the presence of https://github.com/dependabot/dependabot-core/issues/390 suggests it will not. This repository doesn't have a `Dockerfile`, only a `compose.yml`.