### PR TITLE
Expose the deployed software version via nginx

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# The REPOSITORY_*, ZULIP_*, and TAG_FILE vars are used by deploy.sh
+# REPOSITORY_*, ZULIP_*, TAG_FILE, DEPLOYED_VERSION_FILE are used by deploy.sh
 TAG_FILE=/home/build/deployment/tag_to_deploy
 REPOSITORY_PREFIX=https://raw.githubusercontent.com/PhilanthropyDataCommons/deploy
 REPOSITORY_FILE=compose.yml
@@ -7,6 +7,8 @@ ZULIP_BOT_EMAIL_ADDRESS=
 ZULIP_BOT_API_KEY=
 ZULIP_STREAM=
 ZULIP_TOPIC=
+# DEPLOYED_VERSION_FILE is served by reverse proxy
+DEPLOYED_VERSION_FILE=/home/reverse-proxy/software-version
 
 # This var (and others above and below) are used by renewCerts.sh
 WEB_SERVER_HOSTNAME=replace_this_with_the_pdc_service_hostname

--- a/compose.yml
+++ b/compose.yml
@@ -15,6 +15,8 @@ services:
       - ${WEB_KEY}:/opt/bitnami/nginx/conf/web-key.pem:ro
       # When using letsencrypt, symlinks may go up a directory, mount whole dir
       - /etc/letsencrypt:/etc/letsencrypt:ro
+      # Expose the currently deployed version id
+      - ${DEPLOYED_VERSION_FILE}:/app/software-version:ro
     depends_on:
       web:
         condition: service_healthy

--- a/deploy.sh
+++ b/deploy.sh
@@ -37,6 +37,7 @@ $DOCKER_COMPOSE_COMMAND version || exit 1
 
 test ! -z "$REPOSITORY_PREFIX" || exit 3
 test ! -z "$REPOSITORY_FILE" || exit 4
+test ! -z "$DEPLOYED_VERSION_FILE" || exit 12
 
 function fin() {
     # Exit. Also notify of the result via chat if an API key is present.
@@ -122,5 +123,7 @@ fi
 $DOCKER_COMPOSE_COMMAND -f "$NEW_COMPOSE_FILE" up -d || fin 11
 echo "$NEW_COMPOSE_FILE" > $COMPOSE_NAME_FILE
 
-fin 0
+# Let nginx serve the current version of the software (compose file)
+echo "$VERSION" > $DEPLOYED_VERSION_FILE
 
+fin 0

--- a/proxy.conf.example
+++ b/proxy.conf.example
@@ -20,6 +20,12 @@ server {
     proxy_set_header Host $http_host;
     proxy_set_header X-NginX-Proxy true;
 
+    # The overall software version currently deployed in this environment.
+    location = /software-version {
+        root /app;
+        try_files /software-version =404;
+    }
+
     # The PDC API implementation, the web service.
     location / {
         proxy_pass http://web:3000;


### PR DESCRIPTION
Before this change, there was no way to tell what version of the software is currently running on the system. This made it impossible for a CI script, for example, to ask which version is currently there. With this change, a CI script (e.g. in a GH action) can ask which version is deployed on the test environment, verify that a page or two return HTTP 200 (besides this one), and then auto-deploy to production with some confidence that the production deployment will succeed.

This removes one of the objections to the current deployment pipeline and also removes the objection to the reason we do not yet have automatic deployments to production: the test auto-deployment should succeed prior to a production auto-deployment.