### PR TITLE
Use shellcheck to lint shell scripts

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,12 @@
+on:
+  pull_request:
+  push:
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,8 @@ jobs:
   shellcheck:
     name: Shellcheck
     runs-on: ubuntu-latest
+    env:
+      SHELLCHECK_OPTS: -x
     steps:
       - uses: actions/checkout@v3
       - name: Run ShellCheck

--- a/deploy.sh
+++ b/deploy.sh
@@ -32,6 +32,7 @@ fi
 $DOCKER_COMPOSE_COMMAND version || exit 1
 
 # Source some environment variables, ensure they are non-empty.
+# shellcheck source=.env.example
 . .env || exit 2
 
 test ! -z "$REPOSITORY_PREFIX" || exit 3
@@ -44,8 +45,8 @@ function fin() {
 
     if [[ "$exit_code" -eq "0" ]]; then
 	# Remove the tag file because it has been processed successfully.
-	rm -f $TAG_FILE
-	rmdir $LOCK_DIR
+	rm -f "$TAG_FILE"
+	rmdir "$LOCK_DIR"
         # There is a chance either of the above do not succeed and this message
 	# is a lie. But the deployment part really did happen, so it is OK, and
 	# also the next attempt to deploy will see a lock directory and report
@@ -54,15 +55,15 @@ function fin() {
     fi
 
     if test ! -z "$ZULIP_BOT_API_KEY"; then
-	curl -X POST ${ZULIP_BASE_URL}/api/v1/messages \
-	     -u ${ZULIP_BOT_EMAIL_ADDRESS}:${ZULIP_BOT_API_KEY} \
+	curl -X POST "${ZULIP_BASE_URL}/api/v1/messages" \
+	     -u "${ZULIP_BOT_EMAIL_ADDRESS}:${ZULIP_BOT_API_KEY}" \
 	     --data-urlencode type=stream \
-	     --data-urlencode to=${ZULIP_STREAM} \
-	     --data-urlencode topic=${ZULIP_TOPIC} \
+	     --data-urlencode "to=${ZULIP_STREAM}" \
+	     --data-urlencode "topic=${ZULIP_TOPIC}" \
 	     --data-urlencode "content=${message}"
     fi
 
-    exit $exit_code
+    exit "$exit_code"
 }
 
 # The tag file is expected to contain a tag to release on line 1.
@@ -87,17 +88,17 @@ if [[ ! -f $TAG_FILE ]]; then
 fi
 
 
-VERSION=$(head -n 1 $TAG_FILE | egrep '^[a-zA-Z0-9\_\.\-]+$')
+VERSION=$(head -n 1 "$TAG_FILE" | grep -E '^[a-zA-Z0-9\_\.\-]+$')
 test ! -z "$VERSION" || fin 6
 
 # In the filename, replace slashes with underscores. This way, we can
 # test from a branch or other url containing slashes and still have a
 # valid filename.
-NEW_COMPOSE_FILE=compose-$(echo $VERSION | sed 's/\/\|\\/_/g' ).yml
+NEW_COMPOSE_FILE=compose-$(echo "$VERSION" | sed 's/\/\|\\/_/g' ).yml
 URL_OF_COMPOSE_FILE=$REPOSITORY_PREFIX/$VERSION/$REPOSITORY_FILE
-CURL_STATUS=$(curl -v -L -o $NEW_COMPOSE_FILE $URL_OF_COMPOSE_FILE |& grep "^< HTTP/" | cut -d' ' -f 3)
+CURL_STATUS=$(curl -v -L -o "$NEW_COMPOSE_FILE" "$URL_OF_COMPOSE_FILE" |& grep "^< HTTP/" | cut -d' ' -f 3)
 
-if test ! -f $NEW_COMPOSE_FILE; then
+if test ! -f "$NEW_COMPOSE_FILE"; then
     echo "Failed to get the compose file from $URL_OF_COMPOSE_FILE"
     echo "HTTP status: $CURL_STATUS"
     fin 7
@@ -106,20 +107,20 @@ fi
 EXISTING_COMPOSE_FILE=$(head -n 1 $COMPOSE_NAME_FILE)
 
 # Pull new images from the new file before attempting a down or up.
-$DOCKER_COMPOSE_COMMAND -f $NEW_COMPOSE_FILE pull || fin 8
+$DOCKER_COMPOSE_COMMAND -f "$NEW_COMPOSE_FILE" pull || fin 8
 
 # Stop existing software if present, e.g.
 # docker-compose -f compose.yml down
 if ! test -z "$EXISTING_COMPOSE_FILE"; then
-    $DOCKER_COMPOSE_COMMAND -f $EXISTING_COMPOSE_FILE down || fin 9
+    $DOCKER_COMPOSE_COMMAND -f "$EXISTING_COMPOSE_FILE" down || fin 9
 else
-    $DOCKER_COMPOSE_COMMAND -f $NEW_COMPOSE_FILE down || fin 10
+    $DOCKER_COMPOSE_COMMAND -f "$NEW_COMPOSE_FILE" down || fin 10
 fi
 
 # Start new software, e.g.
 # docker-compose -f compose.yml up -d
-$DOCKER_COMPOSE_COMMAND -f $NEW_COMPOSE_FILE up -d || fin 11
-echo $NEW_COMPOSE_FILE > $COMPOSE_NAME_FILE
+$DOCKER_COMPOSE_COMMAND -f "$NEW_COMPOSE_FILE" up -d || fin 11
+echo "$NEW_COMPOSE_FILE" > $COMPOSE_NAME_FILE
 
 fin 0
 


### PR DESCRIPTION
There is some easy cleanup needed in shell scripts. This change automatically exposes the needed improvements to shell scripts.

Issue #80 Lint the shell scripts