### PR TITLE
Reduce the wait between DB service health checks

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -74,6 +74,6 @@ services:
              "-d", "${PG_DB}",
              "-U", "${PG_USER}",
              "-p", "${PG_PORT}"]
-      interval: 10s
+      interval: 7s
     logging:
       driver: journald


### PR DESCRIPTION
This change should result in lower startup times, from around 30 seconds to under 20 seconds (hopefully under 15 seconds). The idea is that if the database (DB) needs to be running first and it does run first, we can let that check happen before the first check for the web application. Right now I think the first check is at 10s, the web service then starts, next check at 20s, nginx starts, next check at 30s, and it's up then. With this schedule it should be more like first check at 7s, web service starts, second check at 10s, nginx starts, and then by 14s or 20s nginx should be up.

Issue #48 Improve the deployment startup duration