### PR TITLE
Pass env vars appropriately to deployment CI jobs

### DIFF
--- a/.github/workflows/trigger-deployments.yml
+++ b/.github/workflows/trigger-deployments.yml
@@ -7,9 +7,6 @@ on:
 
 env:
   TAG_TO_DEPLOY: ${{ github.ref_name }}
-  BUILD_SSH_PRIVATE_KEY: ${{ secrets.BUILD_SSH_PRIVATE_KEY }}
-  BUILD_SSH_PUBLIC_KEY: ${{ secrets.BUILD_SSH_PUBLIC_KEY }}
-  MACHINE_ADDRESS: ${{ secrets.MACHINE_ADDRESS }}
 
 jobs:
   on-main-branch-check:
@@ -28,6 +25,11 @@ jobs:
   trigger-test-deployment:
     runs-on: ubuntu-latest
     environment: test
+    env:
+      BUILD_SSH_PRIVATE_KEY: ${{ secrets.BUILD_SSH_PRIVATE_KEY }}
+      BUILD_SSH_PUBLIC_KEY: ${{ secrets.BUILD_SSH_PUBLIC_KEY }}
+      MACHINE_ADDRESS: ${{ secrets.MACHINE_ADDRESS }}
+      KNOWN_HOSTS: ${{ secrets.KNOWN_HOSTS }}
     steps:
     - name: Check out repository code to access trigger_deployment.sh
       uses: actions/checkout@v4
@@ -47,6 +49,11 @@ jobs:
     if: ${{ needs.on-main-branch-check.outputs.on_main == 'true' }}
     runs-on: ubuntu-latest
     environment: production
+    env:
+      BUILD_SSH_PRIVATE_KEY: ${{ secrets.BUILD_SSH_PRIVATE_KEY }}
+      BUILD_SSH_PUBLIC_KEY: ${{ secrets.BUILD_SSH_PUBLIC_KEY }}
+      MACHINE_ADDRESS: ${{ secrets.MACHINE_ADDRESS }}
+      KNOWN_HOSTS: ${{ secrets.KNOWN_HOSTS }}
     steps:
     - name: Check out repository code to access trigger_deployment.sh
       uses: actions/checkout@v4


### PR DESCRIPTION
Before this commit, the `KNOWN_HOSTS` variable was not sent to `trigger_deployment.sh`, causing failures. It also seems inappropriate to pass secrets to 3rd-party actions if avoidable, so this commit also removes access to the secrets for the action that checks for the given tag to be on the main branch.

Issue #106 Auto-deploy to production