### PR TITLE
Expect a line terminator in software-version URL

### DIFF
--- a/.github/workflows/trigger-deployments.yml
+++ b/.github/workflows/trigger-deployments.yml
@@ -39,7 +39,7 @@ jobs:
         url: ${{ secrets.DEPLOYED_VERSION_URL }}
         method: GET
         expectStatus: 200
-        expectBody: "${{ env.TAG_TO_DEPLOY }}"
+        expectBodyRegex: "^${{ env.TAG_TO_DEPLOY }}\\W*$"
         timeout: 600000
         interval: 20000
   trigger-production-deployment:
@@ -63,6 +63,6 @@ jobs:
         url: ${{ secrets.DEPLOYED_VERSION_URL }}
         method: GET
         expectStatus: 200
-        expectBody: "${{ env.TAG_TO_DEPLOY }}"
+        expectBodyRegex: "^${{ env.TAG_TO_DEPLOY }}\\W*$"
         timeout: 600000
         interval: 20000


### PR DESCRIPTION
Without this change, the CI action that asks which version is running in a target environment would fail because of a line terminator difference in the expected string versus the returned string.

This change attempts to fix the issue by adding an escaped endline to the expected response body.

Issue #106 Auto-deploy to production