### PR TITLE
Fetch tags to check main branch during auto-deploy

### DIFF
--- a/.github/workflows/trigger-deployments.yml
+++ b/.github/workflows/trigger-deployments.yml
@@ -16,7 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 20
+          fetch-depth: 0
+          fetch-tags: true
       - uses: rickstaa/action-contains-tag@v1
         id: contains_tag
         with:


### PR DESCRIPTION
In order to check whether the checked-out tag is part of the main branch, the tags (including branch names) need to be present for the check to succeed.

Issue #106 Auto-deploy to production